### PR TITLE
@Nate158eTh's untitled project

### DIFF
--- a/README.md/@Nate158eTh's untitled project
+++ b/README.md/@Nate158eTh's untitled project
@@ -1,0 +1,68 @@
+# sbt-validator
+Builds sbt 1.0.x against recent versions of the sbt modules
+การพึ่งพา:
+	Jansson 2.0 พร้อมการสนับสนุน 'ยาวยาว'
+
+ตัวอย่างการพึ่งพา:
+	Jansson 2.1 (เพื่ออ่าน JSON จาก stdin)
+	libgcrypt (สำหรับ SHA256)
+
+สำหรับการใช้งาน โปรดดูที่ example.c
+โปรดทราบว่าคุณต้องกำหนด blkmk_sha256_impl ให้กับตัวชี้ฟังก์ชัน:
+	bool mysha256 (เป็นโมฆะ * hash_out, const เป็นโมฆะ * data, size_t datasz)
+hash_out จะต้องสามารถทับซ้อนกับข้อมูลได้!
+
+โปรดทราบด้วยว่าคุณไม่ควรหมุนเวลาสำหรับการดึงข้อมูล ในขณะที่มันจะ
+อาจใช้ได้ ไม่มีการรับประกันว่าจะไม่อยู่นอกขีดจำกัดเวลาสูงสุด
+สำหรับเทมเพลตบล็อก เป็นการดีที่สุดที่จะรับข้อมูลเพิ่มเติมบ่อยๆ
+ตามความจำเป็น
+ระบบปฏิบัติการ: linux
+ภาษา: c
+คอมไพเลอร์: gcc
+sudo: เท็จ
+เมทริกซ์:
+  รวม:
+    - คอมไพเลอร์: ": เสร็จสมบูรณ์"
+      env: CONFIGURE_OPTS="--enable-tool --enable-static --enable-shared" MAKE_CHECK=1
+      ส่วนเสริม:
+        ฉลาด:
+            แพ็คเกจ:
+            - สร้างสำคัญ
+            - libgcrypt11-dev
+    - คอมไพเลอร์: ": ไม่มีเครื่องมือ/การทดสอบ"
+      env: CONFIGURE_OPTS="--disable-tool --enable-static --enable-shared"
+      ส่วนเสริม:
+        ฉลาด:
+            แพ็คเกจ:
+            - สร้างสำคัญ
+    - คอมไพเลอร์: ": Win32 - ไม่มีเครื่องมือ/การทดสอบ"
+      env: CONFIGURE_OPTS="--disable-tool --host=i686-w64-mingw32 --enable-static --enable-shared"
+      ส่วนเสริม:
+        ฉลาด:
+            แพ็คเกจ:
+            - gcc-mingw-w64-i686
+            - binutils-mingw-w64-i686
+            - mingw-w64-i686-dev
+    - คอมไพเลอร์: ": Win64 - ไม่มีเครื่องมือ/การทดสอบ"
+      env: CONFIGURE_OPTS="--disable-tool --host=x86_64-w64-mingw32 --enable-static --enable-shared"
+      ส่วนเสริม:
+        ฉลาด:
+            แพ็คเกจ:
+            - gcc-mingw-w64-x86-64
+            - binutils-mingw-w64-x86-64
+            - mingw-w64-x86-64-dev
+  ไม่รวม:
+    - คอมไพเลอร์: gcc
+ติดตั้ง:
+    - ถ้า [ -n "$PACKAGES" ]; จากนั้น travis_retry sudo apt-get update; fi
+    - ถ้า [ -n "$PACKAGES" ]; จากนั้น travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
+สคริปต์:
+    - ยกเลิกการตั้งค่า CC
+    - ./autogen.sh
+    - ./configure $CONFIGURE_OPTS || tail -n 1000 config.log
+    - ทำ
+    - ทดสอบ -z "$MAKE_CHECK" || ทำการตรวจสอบ
+    - ทำการติดตั้ง DESTDIR=$PWD/ii
+    - cd ii && ค้นหา
+@Nate158eTh's untitled project
+"Scripts and tools" 


### PR DESCRIPTION
README
การพึ่งพา:
	Jansson 2.0 พร้อมการสนับสนุน 'ยาวยาว'

ตัวอย่างการพึ่งพา:
	Jansson 2.1 (เพื่ออ่าน JSON จาก stdin)
	libgcrypt (สำหรับ SHA256)

สำหรับการใช้งาน โปรดดูที่ example.c. เรียกใช้ "สร้างตัวอย่าง" เพื่อสร้าง

โปรดทราบว่าคุณต้องกำหนด blkmk_sha256_impl ให้กับตัวชี้ฟังก์ชัน:
	bool mysha256 (เป็นโมฆะ * hash_out, const เป็นโมฆะ * data, size_t datasz)
hash_out จะต้องสามารถทับซ้อนกับข้อมูลได้!

นอกจากนี้ โปรดทราบด้วยว่าคุณไม่ควร roll ntime สำหรับข้อมูลที่ดึงมาโดยไม่ได้ระบุอย่างชัดเจน
ตรวจสอบว่าอยู่ภายในข้อจำกัดของเทมเพลต (mintime, maxtime,
mintimeoff และ maxtimeoff); อ่านข้อกำหนด BIP 23 โดยละเอียดถึง
เข้าใจวิธีการทำงาน เป็นการดีที่สุดที่จะรับข้อมูลเพิ่มเติมบ่อยๆ
ตามความจำเป็น สำหรับ blkmk_get_mdata คุณอาจระบุว่าคุณต้องการม้วน
ส่วนหัว ntime เพียงครั้งเดียวต่อวินาทีเวลาใช้งานที่ผ่านมา - จากนั้นจะตั้งค่า
*out_expires เพื่อให้การหมดอายุเกิดขึ้นก่อนที่คุณจะม้วนเกิน ntime . ใดๆ
ขีดจำกัด หากคุณกำลังหมุน ntime ในอัตราใด ๆ ที่ไม่ใช่หนึ่งครั้งต่อวินาที คุณ
ไม่ควรระบุ can_roll_ntime เป็น blkmk_get_mdata และต้องตรวจสอบว่า your
การใช้งานอยู่ภายในเทมเพลตที่ชัดเจน จำกัด ตัวคุณเอง
ระบบปฏิบัติการ: linux
ภาษา: c
คอมไพเลอร์: gcc
sudo: เท็จ
เมทริกซ์:
  รวม:
    - คอมไพเลอร์: ": เสร็จสมบูรณ์"
      env: CONFIGURE_OPTS="--enable-tool --enable-static --enable-shared" MAKE_CHECK=1
      ส่วนเสริม:
        ฉลาด:
            แพ็คเกจ:
            - สร้างสำคัญ
            - libgcrypt11-dev
    - คอมไพเลอร์: ": ไม่มีเครื่องมือ/การทดสอบ"
      env: CONFIGURE_OPTS="--disable-tool --enable-static --enable-shared"
      ส่วนเสริม:
        ฉลาด:
            แพ็คเกจ:
            - สร้างสำคัญ
    - คอมไพเลอร์: ": Win32 - ไม่มีเครื่องมือ/การทดสอบ"
      env: CONFIGURE_OPTS="--disable-tool --host=i686-w64-mingw32 --enable-static --enable-shared"
      ส่วนเสริม:
        ฉลาด:
            แพ็คเกจ:
            - gcc-mingw-w64-i686
            - binutils-mingw-w64-i686
            - mingw-w64-i686-dev
    - คอมไพเลอร์: ": Win64 - ไม่มีเครื่องมือ/การทดสอบ"
      env: CONFIGURE_OPTS="--disable-tool --host=x86_64-w64-mingw32 --enable-static --enable-shared"
      ส่วนเสริม:
        ฉลาด:
            แพ็คเกจ:
            - gcc-mingw-w64-x86-64
            - binutils-mingw-w64-x86-64
            - mingw-w64-x86-64-dev
  ไม่รวม:
    - คอมไพเลอร์: gcc
ติดตั้ง:
    - ถ้า [ -n "$PACKAGES" ]; จากนั้น travis_retry sudo apt-get update; fi
    - ถ้า [ -n "$PACKAGES" ]; จากนั้น travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
สคริปต์:
    - ยกเลิกการตั้งค่า CC
    - ./autogen.sh
    - ./configure $CONFIGURE_OPTS || tail -n 1000 config.log
    - ทำ
    - ทดสอบ -z "$MAKE_CHECK" || ทำการตรวจสอบ
    - ทำการติดตั้ง DESTDIR=$PWD/ii
    - cd ii && ค้นหา
การเริ่มต้น
ก่อนที่คุณจะสามารถใช้ libbase58 สำหรับ base58check คุณต้องจัดเตรียมฟังก์ชัน SHA256 ลายเซ็นฟังก์ชันที่ต้องการคือ:

bool my_sha256(void *digest, const void *data, size_t datasz)
เพียงกำหนดฟังก์ชันของคุณให้กับ b58_sha256_impl:

b58_sha256_impl = my_sha256;
สิ่งนี้จำเป็นเฉพาะในกรณีที่ใช้ base58check Raw base58 ไม่ต้องการ SHA256

ถอดรหัส Base58
เพียงจัดสรรบัฟเฟอร์เพื่อเก็บข้อมูลไบนารี และตั้งค่าตัวแปรด้วยขนาดบัฟเฟอร์ แล้วเรียกใช้ฟังก์ชัน b58tobin:

bool b58tobin(void *bin, size_t *binsz, const char *b58, size_t b58sz)
ความยาว base58 ไบต์ "ตามรูปแบบบัญญัติ" จะถูกกำหนดให้กับ binsz เมื่อสำเร็จ ซึ่งอาจมากกว่าบัฟเฟอร์จริงหากอินพุตมีเลขศูนย์นำหน้าจำนวนมาก จะใช้บัฟเฟอร์ไบนารีแบบเต็มโดยไม่คำนึงถึงความยาวไบต์ตามรูปแบบบัญญัติ หาก b58sz เป็นศูนย์ จะมีการเริ่มต้นด้วย strlen(b58); โปรดทราบว่าไม่รองรับสตริง base58 ที่มีความยาวเป็นศูนย์จริงที่นี่

กำลังตรวจสอบ Base58Check
หลังจากเรียก b58tobin คุณสามารถตรวจสอบข้อมูล base58check ได้โดยใช้ฟังก์ชัน b58check:

int b58check(const void *bin, size_t binsz, const char *b58, size_t b58sz)
เรียกมันด้วยบัฟเฟอร์เดียวกันกับที่ใช้สำหรับ b58tobin ถ้าค่าส่งกลับเป็นค่าลบ แสดงว่าเกิดข้อผิดพลาด มิฉะนั้น ค่าที่ส่งคืนคือไบต์ "รุ่น" ของ base58check จากข้อมูลที่ถอดรหัส

การเข้ารหัส Base58
จัดสรรสตริงเพื่อจัดเก็บเนื้อหา base58 สร้างตัวแปร size_t ด้วยขนาดของการจัดสรรนั้น และเรียก:

bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz)
โปรดทราบว่าคุณต้องส่งตัวชี้ไปยังตัวแปรขนาดสตริง ไม่ใช่ตัวขนาด เมื่อ b58enc ส่งคืน ตัวแปรจะถูกแก้ไขเพื่อให้มีจำนวนไบต์ที่ใช้จริง (รวมถึงตัวสิ้นสุดค่า null) ถ้าการเข้ารหัสล้มเหลวด้วยเหตุผลใดก็ตาม หรือถ้าบัฟเฟอร์สตริงไม่ใหญ่พอสำหรับผลลัพธ์ b58enc จะส่งกลับค่าเท็จ มิฉะนั้น จะคืนค่าเป็นจริงเพื่อบ่งชี้ความสำเร็จ

การเข้ารหัส Base58Check
การกำหนดเป้าหมาย base58check ทำได้คล้ายกับการเข้ารหัส base58 แบบดิบ แต่คุณต้องระบุไบต์ของเวอร์ชันด้วย:

bool b58check_enc(char *b58c, size_t *b58c_sz, uint8_t ver,
                  const void *data,